### PR TITLE
Add matrix periodic build

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,7 +6,7 @@ Only the last build of docker images are supported. All built versions of arma3s
 
 ## Reporting vulnerabilities
 
-We use [dependabot](https://github.com/dependabot/dependabot-core) to maintain our docker images up-to-date regarding dependancies. Vulnerabilities may still be found in the docker images, which you can report by [opening a github issue](https://github.com/ArwynFr/arma3sync-docker/issues).
+We use a periodic matrix build to maintain our docker images up-to-date regarding dependancies. Vulnerabilities may still be found in the docker images, which you can report by [opening a github issue](https://github.com/ArwynFr/arma3sync-docker/issues).
 
 In case of vulnerability in arma3sync, please contact the author on [the arma3sync thread on Bohemia Interactive Forums](https://forums.bohemia.net/forums/topic/152942-arma3sync-launcher-and-addons-synchronization-software-for-arma-3/).
 

--- a/.github/USAGE.md
+++ b/.github/USAGE.md
@@ -4,14 +4,22 @@
 
 ### Tags
 
-Arma3sync-docker provides multiple tags allowing to run different combinations of the software and the java runtime versions. You can specify major or minor version of arma3sync and optionally major versions of the jre. The default jre version is jre11.
+Arma3sync-docker provides multiple tags allowing to run different combinations of the software and the java runtime versions. You can specify major or minor version of arma3sync and optionally major versions of the jre.
+
+The complete list of tags is available on [the project's Docker hub page](https://hub.docker.com/r/arwynfr/arma3sync/tags).
+
+For production usage, you should use `arwynfr/arma3sync:1.7`
 
 #### OpenJDK versions
-*   jre11
+Arma3Sync-docker provides images for the following versions of the OpenJDK runtime:
+*   jre8, version used by arma3sync developpers
+*   jre11, current LTS version of the runtime
+*   jre16, current non-LTS version of the runtime
 
-***Note:** We're working on providing jre 8 versions.*
+***Note:** The default jre version is jre 16. All versions use the latest jre runtime for a given major version with the debian slim variant.*
 
 #### Arma3sync versions
+Arma3Sync-docker provides images for the following versions of Arma3Sync:
 *   1.1.23, 1.1.24, 1.1.30
 *   1.2.37, 1.2.38, 1.2.39, 1.2.40, 1.2.45, 1.2.46, 1.2.47, 1.2.48
 *   1.3.49
@@ -19,7 +27,7 @@ Arma3sync-docker provides multiple tags allowing to run different combinations o
 *   1.5.73, 1.5.75, 1.5.84
 *   1.7.99, 1.7.101, 1.7.103, 1.7.104
 
-***Note:** Arma3Sync 1.6 is not available for jre 11 because it uses Java EE components which are not available with that jre version.*
+***Note:** Arma3Sync 1.6 is not available because it uses Java EE components which are not available with recent jre version.*
 
 ### Environment variables
 
@@ -63,8 +71,8 @@ The easiest way to using this image is by creating a container and runing it. Th
 
 ```console
 $ docker run -it --rm --volume=arma3sync-data:/data arwynfr/arma3sync:1.7
-ArmA3Sync Installed version = 1.6.97
-JRE installed version = 1.8.0_181
+ArmA3Sync Installed version = 1.7.104
+JRE installed version = 16.0.2
 OS Name = Linux
 
 ArmA3Sync console commands:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10

--- a/.github/workflows/build.github-workflow.yml
+++ b/.github/workflows/build.github-workflow.yml
@@ -1,0 +1,23 @@
+name: build
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Build images
+        shell: pwsh
+        run: ./build.ps1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push images
+        run: docker push -a arwynfr/arma3sync


### PR DESCRIPTION
This PR adds a weekly github action to build and push docker images to docker hub. 
It will alow to keep images up-to-date regarding openjdk runtimes.

Fixes #9 
Obsoletes #8 